### PR TITLE
Add Unity Catalog support: UCStorage credential vending and staging mode

### DIFF
--- a/STAGING_MODE.md
+++ b/STAGING_MODE.md
@@ -1,0 +1,181 @@
+# Staging Mode for Unity Catalog Governance
+
+## Why this exists
+
+The default operation of the accelerator writes a Delta `_delta_log` whose
+AddActions reference parquet files at **absolute** `s3a://...` paths. That
+works correctly when the source bucket is registered as a Unity Catalog
+external location. But in the typical Guidewire CDA SaaS deployment, the
+source bucket is owned by Guidewire's AWS account and the customer holds
+only a cross-account read-only IAM grant. UC has no governance reach over
+that bucket.
+
+Without staging:
+- Reads of the resulting Delta table follow the absolute paths using
+  whatever IAM identity the engine has, **bypassing UC**.
+- On serverless compute, those reads fail closed (no IAM fallback).
+- On classic compute with a broad cluster instance profile, the reads
+  silently succeed without UC audit, lineage, or policy enforcement.
+
+Staging mode closes the gap by **copying source parquets into a customer-
+owned bucket** that *can* be a UC external location. The Delta log is then
+written with paths relative to the staged target root, and reads stay
+inside UC.
+
+## When to use it
+
+| Deployment | Staging needed? |
+|---|---|
+| Guidewire CDA SaaS (Guidewire-owned source bucket) | Yes |
+| Self-hosted CDA (customer owns source bucket) | No -- pass `target_storage=UCStorage(...)` without `staging_mode=True` |
+| No Unity Catalog | No -- omit `target_storage` entirely; legacy behavior is preserved |
+
+## Setup
+
+1. **Create the customer-owned target bucket** that will receive staged
+   parquets. Suggested layout:
+
+   ```
+   s3://customer-uc-bucket/staged-cda/
+   ```
+
+2. **Register the bucket prefix as a UC external location** in your
+   workspace, with a UC storage credential whose IAM role has
+   `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, and
+   `s3:ListBucket` on the prefix.
+
+3. **Pre-create the UC tables** under `<catalog>.<schema>` -- one per CDA
+   table you want to land. The accelerator looks up the UC `table_id` for
+   each table at startup; tables that don't exist will fail loudly with
+   an actionable error.
+
+   ```sql
+   CREATE CATALOG IF NOT EXISTS main;
+   CREATE SCHEMA IF NOT EXISTS main.guidewire_cda;
+   CREATE TABLE main.guidewire_cda.cc_claim
+       LOCATION 's3://customer-uc-bucket/staged-cda/cc_claim/';
+   -- ... one per table
+   ```
+
+4. **Configure the accelerator** via env vars (or pass directly to
+   `Processor`):
+
+   ```bash
+   export AWS_MANIFEST_LOCATION=s3://guidewire-bucket/customer-id
+   export AWS_SOURCE_REGION=us-east-1
+   export AWS_SOURCE_ACCESS_KEY_ID=...      # Guidewire's cross-account read grant
+   export AWS_SOURCE_SECRET_ACCESS_KEY=...
+
+   export DELTA_TARGET_CLOUD=aws
+   export AWS_TARGET_S3_BUCKET=customer-uc-bucket
+   export AWS_TARGET_S3_PREFIX=staged-cda
+
+   # Staging-mode opt-in
+   export STAGING_MODE=true
+   export UC_CATALOG_NAME=main
+   export UC_SCHEMA_NAME=guidewire_cda
+   export UC_REGION=us-east-1
+   ```
+
+   ```bash
+   python main.py
+   ```
+
+## Configuration reference
+
+| Env var | Required | Purpose |
+|---|---|---|
+| `STAGING_MODE` | yes (set `true`) | Enables staging |
+| `UC_CATALOG_NAME` | yes | UC catalog containing the target tables |
+| `UC_SCHEMA_NAME` | yes | UC schema (database) within the catalog |
+| `UC_REGION` | no | AWS region for vended creds; falls back to `AWS_REGION` |
+| `DATABRICKS_HOST` | yes | Where to vend UC credentials from |
+| `DATABRICKS_TOKEN` | yes | Auth for the WorkspaceClient |
+
+The Databricks SDK's default auth chain applies, so any of the standard
+mechanisms (host+token, OAuth, profile) work in place of explicit env vars.
+
+## What staging does, step by step
+
+For each table in the manifest:
+
+1. Resolve the UC `table_id` for `<catalog>.<schema>.<table_name>`.
+2. Vend short-lived AWS credentials via the SDK's
+   `temporary_table_credentials` API. These are scoped to the UC table's
+   storage credential -- not your account-wide IAM.
+3. List source parquets for each new timestamp folder (driven by the
+   existing watermark mechanism -- no re-staging of already-processed
+   timestamps).
+4. For each parquet:
+   - `head_object` on the target. If a file of the same size already
+     exists, skip the copy.
+   - Otherwise stream the bytes from source to target via PyArrow's S3
+     filesystem.
+5. Write the AddAction with a **path relative to the table root** -- e.g.
+   `<schema_hash>/<timestamp>/part-0.parquet`. This is required for UC
+   governance to track the file.
+6. Commit one Delta transaction per timestamp folder, advancing the
+   watermark. A failed copy aborts the transaction *before* the watermark
+   advances; restart resumes cleanly.
+
+## Limitations (v1)
+
+- **AWS source -> AWS UC target only.** Cross-cloud staging (Azure CDA ->
+  AWS UC, etc.) raises `NotImplementedError` in `StagingExecutor`.
+- **Sequential within-table copy.** Cross-table parallelism is preserved
+  via Ray; within a single table, files are staged serially. Adequate for
+  typical CDA volumes; can be parallelized in a follow-on.
+- **Idempotency uses size match.** If a previous run failed mid-stream
+  and left a partial parquet at the target whose byte count happens to
+  match the source, the next run will skip it. The window is small
+  (single file's copy duration) and the typical recovery is to delete
+  any stale targets manually before re-running. A future hardening pass
+  could use a temp-key + atomic-rename pattern.
+- **Pre-create UC tables.** The accelerator does not create UC tables;
+  it only resolves their `table_id` for credential vending. Customers
+  must register tables with appropriate `LOCATION` clauses ahead of
+  the first run.
+
+## Programmatic API (without env vars)
+
+For customers wiring the accelerator into a custom workflow:
+
+```python
+from guidewire import Processor, UCStorage, Batch
+
+processor = Processor(
+    target_cloud="aws",
+    table_names=("cc_claim", "cc_exposure", "cc_check"),
+    parallel=False,
+    staging_mode=True,
+    uc_catalog="main",
+    uc_schema="guidewire_cda",
+    uc_region="us-east-1",
+)
+processor.run()
+```
+
+Or per-batch, with explicit `UCStorage`:
+
+```python
+uc = UCStorage(uc_table_id="<resolved-table-id>", region="us-east-1")
+batch = Batch(
+    table_name="cc_claim",
+    manifest=manifest,
+    target_cloud="aws",
+    storage_or_s3_name="customer-uc-bucket",
+    storage_container=None,
+    target_storage=uc,
+    staging_mode=True,
+)
+batch.process_batch()
+```
+
+## Backward compatibility
+
+Staging mode is fully opt-in. With no `staging_mode` and no
+`target_storage` passed, every code path in this module is unreachable;
+the accelerator emits absolute `s3a://...` AddAction paths exactly as
+the upstream did. See `testing/tests/test_target_cloud_config.py` and
+`testing/tests/test_staging_unit.py` for explicit regression-guard
+tests covering the legacy paths.

--- a/guidewire/__init__.py
+++ b/guidewire/__init__.py
@@ -10,6 +10,7 @@ from .manifest import Manifest
 from .results import Result
 from .delta_log import AzureDeltaLog, AWSDeltaLog, DeltaError, DeltaValidationError
 from .storage import AzureStorage, AWSStorage, BaseStorage, UCStorage
+from .staging import StagingExecutor
 from .progress_managers import SimpleProgressManager, MultiProgressManager
 
 __version__ = "0.0.4"
@@ -28,6 +29,7 @@ __all__ = [
     "AWSStorage",
     "BaseStorage",
     "UCStorage",
+    "StagingExecutor",
     "SimpleProgressManager",
     "MultiProgressManager", 
 ]

--- a/guidewire/__init__.py
+++ b/guidewire/__init__.py
@@ -9,7 +9,7 @@ from .batch import Batch
 from .manifest import Manifest
 from .results import Result
 from .delta_log import AzureDeltaLog, AWSDeltaLog, DeltaError, DeltaValidationError
-from .storage import AzureStorage, AWSStorage
+from .storage import AzureStorage, AWSStorage, BaseStorage, UCStorage
 from .progress_managers import SimpleProgressManager, MultiProgressManager
 
 __version__ = "0.0.4"
@@ -26,6 +26,8 @@ __all__ = [
     "DeltaValidationError",
     "AzureStorage",
     "AWSStorage",
+    "BaseStorage",
+    "UCStorage",
     "SimpleProgressManager",
     "MultiProgressManager", 
 ]

--- a/guidewire/batch.py
+++ b/guidewire/batch.py
@@ -4,6 +4,7 @@ from pyarrow.fs import FileType
 from guidewire.logging import logger as L
 from guidewire.delta_log import AzureDeltaLog, AWSDeltaLog
 from guidewire.manifest import Manifest
+from guidewire.storage import BaseStorage
 from typing import Optional
 from guidewire.results import Result
 from datetime import datetime
@@ -22,9 +23,10 @@ class Batch:
         progress_manager = None,
         parallel: bool = False,
         maintain_timestamp_transactions: bool = True,
+        target_storage: Optional[BaseStorage] = None,
     ):
         """Initialize a new Batch instance.
-        
+
         Args:
             table_name: Name of the table to process
             manifest: Manifest object containing file information
@@ -36,6 +38,11 @@ class Batch:
             progress_manager: Optional progress manager (Ray actor if parallel=True)
             parallel: Whether this batch is running in parallel mode with Ray
             maintain_timestamp_transactions: Whether to maintain timestamp transactions (default: True)
+            target_storage: Optional pre-configured storage instance for the
+                target Delta log. AWS-only today. When omitted, the legacy
+                ``AWSStorage(prefix="TARGET")`` default is used. Pass a
+                :class:`guidewire.storage.UCStorage` instance to write the
+                Delta log under Unity Catalog governance.
         Raises:
             ValueError: If required parameters are invalid
         """
@@ -47,7 +54,7 @@ class Batch:
             raise ValueError("storage_or_s3_name must be a non-empty string")
         if target_cloud == "azure" and (not storage_container or not isinstance(storage_container, str)):
             raise ValueError("storage_container must be a non-empty string for Azure target cloud")
-            
+
         self.table_name = table_name
         self.manifest = manifest
         self.entry = self.manifest.read(entry=self.table_name)
@@ -66,6 +73,7 @@ class Batch:
                 bucket_name=storage_or_s3_name,
                 table_name=self.table_name,
                 subfolder=subfolder,
+                storage=target_storage,
             )
         else:
             raise ValueError(f"Invalid target_cloud: {target_cloud}. Must be 'azure' or 'aws'")
@@ -210,11 +218,20 @@ class Batch:
 
 
     def _get_parquet_list(self, directory: str) -> list[dict]:
-        """Returns a list of parquet files with metadata from the given directory."""
+        """Returns a list of parquet files with metadata from the given directory.
+
+        The AddAction ``path`` is delegated to the target storage's
+        :meth:`guidewire.storage.BaseStorage.log_action_path`. This is
+        polymorphic: :class:`AWSStorage` returns the legacy ``s3a://...``
+        absolute path; :class:`UCStorage` returns a path relative to the
+        table root (or raises if the source isn't enclosed by the root).
+        """
+        target_fs = self.log_entry.fs
+        table_root = self.log_entry.log_uri
         return [
             {
                 "relative_path": file.path,
-                "path": f"s3a://{file.path}",
+                "path": target_fs.log_action_path(file.path, table_root),
                 "last_modified": file.mtime_ns,
                 "size": file.size,
             }

--- a/guidewire/batch.py
+++ b/guidewire/batch.py
@@ -4,7 +4,8 @@ from pyarrow.fs import FileType
 from guidewire.logging import logger as L
 from guidewire.delta_log import AzureDeltaLog, AWSDeltaLog
 from guidewire.manifest import Manifest
-from guidewire.storage import BaseStorage
+from guidewire.storage import BaseStorage, UCStorage
+from guidewire.staging import StagingExecutor
 from typing import Optional
 from guidewire.results import Result
 from datetime import datetime
@@ -24,6 +25,7 @@ class Batch:
         parallel: bool = False,
         maintain_timestamp_transactions: bool = True,
         target_storage: Optional[BaseStorage] = None,
+        staging_mode: bool = False,
     ):
         """Initialize a new Batch instance.
 
@@ -43,6 +45,12 @@ class Batch:
                 ``AWSStorage(prefix="TARGET")`` default is used. Pass a
                 :class:`guidewire.storage.UCStorage` instance to write the
                 Delta log under Unity Catalog governance.
+            staging_mode: When True, copy each source parquet into the
+                target table root before recording its AddAction. This is
+                required for Guidewire CDA SaaS deployments where the source
+                bucket cannot be registered as a UC external location.
+                Requires ``target_storage`` to be a :class:`UCStorage`
+                instance and ``target_cloud='aws'``.
         Raises:
             ValueError: If required parameters are invalid
         """
@@ -77,6 +85,28 @@ class Batch:
             )
         else:
             raise ValueError(f"Invalid target_cloud: {target_cloud}. Must be 'azure' or 'aws'")
+        # Optional staging executor for UC-governed CDA pipelines.
+        # Constructed only when staging_mode=True; otherwise None and Batch
+        # behaves exactly as before.
+        self.staging_executor: Optional[StagingExecutor] = None
+        if staging_mode:
+            if not isinstance(target_storage, UCStorage):
+                raise ValueError(
+                    "staging_mode=True requires target_storage to be a UCStorage "
+                    "instance (staging only makes sense when the target is UC-governed)."
+                )
+            if target_cloud != "aws":
+                raise NotImplementedError(
+                    f"staging_mode=True is supported only for target_cloud='aws' in v1; "
+                    f"got target_cloud={target_cloud!r}."
+                )
+            self.staging_executor = StagingExecutor(
+                source_storage=self.manifest.fs,
+                target_storage=target_storage,
+                target_table_root=self.log_entry.log_uri,
+                source_table_root=self.entry["dataFilesPath"],
+            )
+
         self.watermark_info = self.log_entry._get_watermark_from_log()
         self.low_watermark = 0 if reset else self.watermark_info["watermark"]
         self.watermark_schema_timestamp = 0 if reset else self.watermark_info["schema_timestamp"]
@@ -220,14 +250,44 @@ class Batch:
     def _get_parquet_list(self, directory: str) -> list[dict]:
         """Returns a list of parquet files with metadata from the given directory.
 
-        The AddAction ``path`` is delegated to the target storage's
-        :meth:`guidewire.storage.BaseStorage.log_action_path`. This is
-        polymorphic: :class:`AWSStorage` returns the legacy ``s3a://...``
-        absolute path; :class:`UCStorage` returns a path relative to the
-        table root (or raises if the source isn't enclosed by the root).
+        Three behaviors, mutually exclusive:
+
+        1. **Legacy (no target_storage, no staging)**: ``log_action_path`` on
+           the default :class:`AWSStorage` returns absolute ``s3a://...``
+           paths -- bit-identical to the upstream behavior.
+        2. **UC mode without staging**: ``target_storage`` is a
+           :class:`UCStorage`; ``log_action_path`` emits paths relative to the
+           target table root. Source files must already be enclosed by the
+           target root (i.e. customer pre-staged or self-hosted CDA layout).
+        3. **UC mode with staging**: each source parquet is copied into the
+           target table root via :class:`StagingExecutor`, and the AddAction
+           records a path relative to that staged location.
+
+        The dispatch happens via polymorphism on the target storage; this
+        method does not know about specific storage subclasses.
         """
         target_fs = self.log_entry.fs
         table_root = self.log_entry.log_uri
+        source_files = [
+            file
+            for file in self.manifest.fs.get_file_info(directory)
+            if file.type == FileType.File and file.path.endswith(".parquet")
+        ]
+
+        if self.staging_executor is not None:
+            return [
+                {
+                    "relative_path": file.path,
+                    "path": target_fs.log_action_path(
+                        self.staging_executor.stage_file(file.path, file.size),
+                        table_root,
+                    ),
+                    "last_modified": file.mtime_ns,
+                    "size": file.size,
+                }
+                for file in source_files
+            ]
+
         return [
             {
                 "relative_path": file.path,
@@ -235,8 +295,7 @@ class Batch:
                 "last_modified": file.mtime_ns,
                 "size": file.size,
             }
-            for file in self.manifest.fs.get_file_info(directory)
-            if file.type == FileType.File and file.path.endswith(".parquet")
+            for file in source_files
         ]
 
     def _get_parquet_schema(self, path: str) -> pa.schema:

--- a/guidewire/delta_log.py
+++ b/guidewire/delta_log.py
@@ -6,7 +6,7 @@ from deltalake.schema import Schema as DeltaSchema
 from deltalake import DeltaTable, PostCommitHookProperties, write_deltalake
 import pyarrow as pa
 from guidewire.logging import logger as L
-from guidewire.storage import AzureStorage, AWSStorage
+from guidewire.storage import AzureStorage, AWSStorage, BaseStorage
 from typing import List, Dict, Optional, Union, Literal
 import os
 
@@ -412,28 +412,35 @@ class AWSDeltaLog(BaseDeltaLog):
         bucket_name: str,
         table_name: str,
         subfolder: Optional[str] = None,
+        storage: Optional[BaseStorage] = None,
     ) -> None:
         """Initialize the AWS S3 Delta log instance.
-        
+
         Args:
             bucket_name: The S3 bucket name
             table_name: The name of the Delta table
             subfolder: Optional subfolder path
-            
+            storage: Optional pre-configured storage instance. If omitted,
+                an :class:`AWSStorage` is constructed with the ``TARGET``
+                env-var prefix (legacy behavior). Pass a :class:`UCStorage`
+                instance to write the Delta log under Unity Catalog
+                governance with credential vending.
+
         Raises:
             DeltaValidationError: If any of the required parameters are empty
         """
         super().__init__()
-        
+
         if not all([bucket_name, table_name]):
             raise DeltaValidationError("bucket_name and table_name must be non-empty strings")
-        
+
         self.bucket_name = bucket_name
         self.table_name = table_name
         self.subfolder = subfolder
-        
-        # Initialize AWS storage with TARGET prefix for delta table writing credentials
-        self.fs = AWSStorage(prefix="TARGET")
+
+        # Use the caller-supplied storage if present; otherwise preserve the
+        # legacy default of AWSStorage(prefix="TARGET").
+        self.fs = storage if storage is not None else AWSStorage(prefix="TARGET")
         self.storage_options = self.fs.storage_options
         
         # Construct log URI and check if log exists

--- a/guidewire/processor.py
+++ b/guidewire/processor.py
@@ -1,20 +1,22 @@
 from typing import Tuple, Optional, Dict
 import os
 import ray
+from databricks.sdk import WorkspaceClient
 from guidewire.manifest import Manifest
 from guidewire.batch import Batch
 from guidewire.logging import logger as L
 from guidewire.results import Result
+from guidewire.storage import UCStorage
 from guidewire.progress_managers import SimpleProgressManager, MultiProgressManager
 class Processor:
     """A class to handle table processing operations."""
-    
-    def __init__(self, target_cloud: str, table_names: Tuple[str, ...] = None, parallel: bool = True, exceptions: list = None, show_progress: bool = True, maintain_timestamp_transactions: bool = True, largest_tables_first_count: int = None) -> None:
+
+    def __init__(self, target_cloud: str, table_names: Tuple[str, ...] = None, parallel: bool = True, exceptions: list = None, show_progress: bool = True, maintain_timestamp_transactions: bool = True, largest_tables_first_count: int = None, staging_mode: bool = False, uc_catalog: Optional[str] = None, uc_schema: Optional[str] = None, uc_region: Optional[str] = None) -> None:
         """Initialize the Processor with table names and parallel processing.
         if table_names is not provided, all tables in the manifest will be processed.
         if parallel is False, the tables will be processed sequentially.
         if parallel is True, the tables will be processed in parallel using Ray.
-        
+
         Args:
             target_cloud: Target cloud provider for delta tables ("azure" or "aws")
             table_names: Tuple of table names to process
@@ -23,16 +25,45 @@ class Processor:
             show_progress: Whether to show table progress (default: True)
             maintain_timestamp_transactions: Whether to maintain timestamp transactions (default: True)
             largest_tables_first_count: Number of largest tables to process first for optimization (default: None, disables ordering)
+            staging_mode: When True, copy each source parquet into the
+                UC-governed target before recording its AddAction. Required
+                for Guidewire CDA SaaS deployments where the source bucket
+                is not registerable as a UC external location. Requires
+                ``target_cloud='aws'`` and ``uc_catalog``/``uc_schema``.
+            uc_catalog: UC catalog name. Combined with ``uc_schema`` and the
+                table name, used to resolve each table's UC table_id at init
+                time via the Databricks SDK.
+            uc_schema: UC schema (database) name within ``uc_catalog``.
+            uc_region: AWS region for ``UCStorage``. Falls back to
+                ``AWS_REGION`` env var if omitted.
         """
         self.table_names = table_names
         self.exceptions = exceptions
         self.parallel = parallel
         self.target_cloud = target_cloud
-        
+
         # Store parameters directly
         self.show_progress = show_progress
         self.maintain_timestamp_transactions = maintain_timestamp_transactions
         self.largest_tables_first_count = largest_tables_first_count
+
+        # Staging-mode configuration. Resolution of UC table_ids is deferred
+        # until after the manifest has been loaded (we need table_names).
+        self.staging_mode = staging_mode
+        self.uc_catalog = uc_catalog
+        self.uc_schema = uc_schema
+        self.uc_region = uc_region
+        self._uc_table_ids: Dict[str, str] = {}
+        if self.staging_mode:
+            if self.target_cloud != "aws":
+                raise NotImplementedError(
+                    f"staging_mode is supported only for target_cloud='aws' in v1; "
+                    f"got target_cloud={self.target_cloud!r}."
+                )
+            if not (self.uc_catalog and self.uc_schema):
+                raise ValueError(
+                    "staging_mode=True requires uc_catalog and uc_schema to be set."
+                )
         
         self._validate_environment()
         
@@ -71,6 +102,35 @@ class Processor:
         
         # Initialize progress manager for sequential processing only if progress should be shown
         self.progress_manager = SimpleProgressManager(show_progress=True) if self.show_progress else None
+
+        # Resolve UC table_ids in staging mode. Done after table_names is
+        # finalised so we know exactly which tables to look up. Performed
+        # via Databricks SDK; the caller's default auth chain is used.
+        if self.staging_mode:
+            self._resolve_uc_table_ids()
+
+    def _resolve_uc_table_ids(self) -> None:
+        """Look up UC table_ids for every table_name via WorkspaceClient.
+
+        Builds ``self._uc_table_ids: Dict[table_name -> uc_table_id]``. Fails
+        loudly if any table is missing in UC -- the customer must register
+        them before running staging mode.
+        """
+        wc = WorkspaceClient()
+        for table_name in self.table_names:
+            full_name = f"{self.uc_catalog}.{self.uc_schema}.{table_name}"
+            try:
+                table_info = wc.tables.get(full_name=full_name)
+            except Exception as e:
+                raise RuntimeError(
+                    f"staging_mode: UC table {full_name!r} could not be resolved. "
+                    f"Pre-create the table in UC before running. ({e})"
+                )
+            if not table_info.table_id:
+                raise RuntimeError(
+                    f"staging_mode: UC returned an empty table_id for {full_name!r}."
+                )
+            self._uc_table_ids[table_name] = table_info.table_id
 
 
     def _validate_environment(self) -> None:
@@ -201,11 +261,22 @@ class Processor:
 
         
     @staticmethod
+    def _build_target_storage_for_staging(uc_table_id: Optional[str], uc_region: Optional[str]):
+        """Construct a UCStorage instance for staging if uc_table_id is provided.
+
+        Returns ``(target_storage, staging_mode)`` -- both ``None``/``False``
+        when ``uc_table_id`` is falsy (legacy / non-staging path).
+        """
+        if not uc_table_id:
+            return None, False
+        return UCStorage(uc_table_id=uc_table_id, region=uc_region), True
+
+    @staticmethod
     @ray.remote
-    def process_table_async(entry: str, manifest: Manifest, target_cloud: str, log_storage_account: str, log_storage_container: str, subfolder: str = None, tracker_actor = None, maintain_timestamp_transactions: bool = True) -> Optional[Result]:
+    def process_table_async(entry: str, manifest: Manifest, target_cloud: str, log_storage_account: str, log_storage_container: str, subfolder: str = None, tracker_actor = None, maintain_timestamp_transactions: bool = True, uc_table_id: Optional[str] = None, uc_region: Optional[str] = None) -> Optional[Result]:
         """
         Process a single table entry asynchronously with Ray.
-        
+
         Args:
             entry: The table name to process
             manifest: The manifest object containing table information
@@ -215,11 +286,14 @@ class Processor:
             subfolder: Optional subfolder name
             tracker_actor: Ray actor for progress tracking
             maintain_timestamp_transactions: Whether to maintain timestamp transactions
+            uc_table_id: When present, instantiate UCStorage and enable staging mode.
+            uc_region: AWS region passed to UCStorage.
         """
         batch_result = None
         try:
             manifest_entry = manifest.read(entry)
             if manifest_entry:
+                target_storage, staging_mode = Processor._build_target_storage_for_staging(uc_table_id, uc_region)
                 batch_result = Batch(
                     table_name=entry,
                     manifest=manifest,
@@ -230,6 +304,8 @@ class Processor:
                     progress_manager=tracker_actor,  # Pass Ray actor directly
                     parallel=True,  # This is the async parallel processing path
                     maintain_timestamp_transactions=maintain_timestamp_transactions,
+                    target_storage=target_storage,
+                    staging_mode=staging_mode,
                 ).process_batch()
                 return batch_result
             else:
@@ -238,10 +314,10 @@ class Processor:
             return batch_result
 
     @staticmethod
-    def process_table(entry: str, manifest: Manifest, target_cloud: str, log_storage_account: str, log_storage_container: str, subfolder: str = None, progress_manager = None, maintain_timestamp_transactions: bool = True) -> Optional[Result]:
+    def process_table(entry: str, manifest: Manifest, target_cloud: str, log_storage_account: str, log_storage_container: str, subfolder: str = None, progress_manager = None, maintain_timestamp_transactions: bool = True, uc_table_id: Optional[str] = None, uc_region: Optional[str] = None) -> Optional[Result]:
         """
         Process a single table entry sequentially (non-parallel).
-        
+
         Args:
             entry: The table name to process
             manifest: The manifest object containing table information
@@ -251,11 +327,14 @@ class Processor:
             subfolder: Optional subfolder name
             progress_manager: Optional progress manager
             maintain_timestamp_transactions: Whether to maintain timestamp transactions
+            uc_table_id: When present, instantiate UCStorage and enable staging mode.
+            uc_region: AWS region passed to UCStorage.
         """
         batch_result = None
         try:
             manifest_entry = manifest.read(entry)
             if manifest_entry:
+                target_storage, staging_mode = Processor._build_target_storage_for_staging(uc_table_id, uc_region)
                 batch_result = Batch(
                     table_name=entry,
                     manifest=manifest,
@@ -266,6 +345,8 @@ class Processor:
                     progress_manager=progress_manager,
                     parallel=False,  # This is the sequential processing path
                     maintain_timestamp_transactions=maintain_timestamp_transactions,
+                    target_storage=target_storage,
+                    staging_mode=staging_mode,
                 ).process_batch()
                 return batch_result
             else:
@@ -298,21 +379,23 @@ class Processor:
                     tracker_actor = multi_progress.get_tracker_actor()
                     futures = [
                         self.process_table_async.remote(
-                            entry, self.manifest, self.target_cloud, 
-                            self.log_storage_account, self.log_storage_container, 
-                            self.subfolder, tracker_actor, self.maintain_timestamp_transactions
+                            entry, self.manifest, self.target_cloud,
+                            self.log_storage_account, self.log_storage_container,
+                            self.subfolder, tracker_actor, self.maintain_timestamp_transactions,
+                            self._uc_table_ids.get(entry), self.uc_region,
                         )
                         for entry in self.table_names
-                    ]      
+                    ]
                     self.results = multi_progress.wait_for_completion(futures)
                     multi_progress.stop()
                 else:
                     # No progress manager, just wait for completion normally
                     futures = [
                         self.process_table_async.remote(
-                            entry, self.manifest, self.target_cloud, 
-                            self.log_storage_account, self.log_storage_container, 
-                            self.subfolder, None, self.maintain_timestamp_transactions
+                            entry, self.manifest, self.target_cloud,
+                            self.log_storage_account, self.log_storage_container,
+                            self.subfolder, None, self.maintain_timestamp_transactions,
+                            self._uc_table_ids.get(entry), self.uc_region,
                         )
                         for entry in self.table_names
                     ]
@@ -327,7 +410,13 @@ class Processor:
                         self.progress_manager.register_table(table_name)
                 
                 for entry in self.table_names:
-                    result = self.process_table(entry, self.manifest, self.target_cloud, self.log_storage_account, self.log_storage_container, self.subfolder, self.progress_manager, self.maintain_timestamp_transactions)
+                    result = self.process_table(
+                        entry, self.manifest, self.target_cloud,
+                        self.log_storage_account, self.log_storage_container,
+                        self.subfolder, self.progress_manager,
+                        self.maintain_timestamp_transactions,
+                        self._uc_table_ids.get(entry), self.uc_region,
+                    )
                     self.results.append(result)
                     
                 if progress_display and self.progress_manager:

--- a/guidewire/staging.py
+++ b/guidewire/staging.py
@@ -1,0 +1,175 @@
+"""Staging executor for Guidewire CDA Unity Catalog governance.
+
+Why this exists
+---------------
+
+Most Guidewire CDA SaaS deployments place source parquet files in an S3
+bucket the customer cannot register as a Unity Catalog external location:
+the bucket is owned by Guidewire's AWS account, and the customer holds only
+a cross-account read-only IAM grant. UC governance, by contrast, requires
+the target Delta table's data to be enclosed under a UC external location
+the customer controls (so vended credentials can govern reads).
+
+This module bridges the two by copying source parquets into a customer-owned
+target prefix that *can* be a UC external location. After staging, the
+accelerator writes the Delta log against the staged target -- AddAction paths
+become relative to the table root, reads stay inside the UC perimeter, and
+``system.access.audit`` attributes them to the UC principal.
+
+Design contract
+---------------
+
+- ``StagingExecutor`` is opt-in. When a ``Batch`` is constructed without one,
+  behavior is bit-identical to the legacy upstream output (absolute s3a://
+  AddAction paths, no copy step, no UC involvement).
+- Reads use the source's :class:`AWSStorage` filesystem (existing
+  ``AWS_SOURCE_*`` env vars). Writes use the target's
+  :class:`UCStorage` filesystem (vended UC creds for the target table).
+  The copy streams bytes between the two filesystems; no third party (and
+  in particular, no static AWS keys with cross-bucket access) sees the data.
+- Idempotency: each per-file copy first checks ``head_object`` on the target.
+  If the target already exists with a matching size, the copy is skipped.
+  This makes re-runs cheap and crash-safe.
+- Atomicity: the existing accelerator already commits one Delta transaction
+  per timestamp folder. Staging happens *within* that transaction's
+  ``_get_parquet_list`` call, so a failed copy aborts the transaction
+  before the watermark advances. Retry resumes naturally.
+
+v1 limitations
+--------------
+
+- AWS source -> AWS UC target only. Cross-cloud (Azure CDA -> AWS UC, etc.)
+  is rejected with ``NotImplementedError``.
+- Serial copy within a table. Cross-table parallelism is unchanged (Ray).
+- Bytes are streamed; no boto3 runtime dependency is added.
+"""
+
+from typing import Optional
+from pyarrow.fs import FileType
+from guidewire.logging import logger as L
+from guidewire.storage import BaseStorage, AWSStorage, UCStorage
+
+
+class StagingExecutor:
+    """Copies CDA parquets from a source filesystem into a UC-governed target.
+
+    Args:
+        source_storage: Filesystem authenticated for reading the source CDA
+            bucket (typically ``AWSStorage(prefix="SOURCE")``).
+        target_storage: Filesystem authenticated for writing into the target
+            UC-governed bucket (typically a :class:`UCStorage` instance with
+            ``operation="READ_WRITE"``).
+        target_table_root: Bucket-relative prefix that encloses the staged
+            data (e.g. ``"customer-bucket/staged/cc_claim"``). Files are
+            staged at ``target_table_root/<schema_hash>/<timestamp>/*.parquet``.
+            This must match the AddAction table root for the relative-path
+            log to resolve correctly under UC.
+        source_table_root: Bucket-relative prefix where source files currently
+            live (e.g. ``"guidewire-bucket/cc_claim"``). The staged path of
+            each file is computed as ``target_table_root + (file.path - source_table_root)``.
+        chunk_size: Streaming chunk size for the cross-filesystem copy
+            (default 8 MB).
+
+    Raises:
+        ValueError: If ``target_storage`` is not a :class:`UCStorage`. Staging
+            into a non-UC target makes no sense -- the whole point is to put
+            data under UC governance.
+        NotImplementedError: If a non-AWS source is passed (cross-cloud staging
+            is out of scope for v1).
+    """
+
+    DEFAULT_CHUNK_SIZE = 8 * 1024 * 1024  # 8 MB
+
+    def __init__(
+        self,
+        source_storage: BaseStorage,
+        target_storage: BaseStorage,
+        target_table_root: str,
+        source_table_root: str,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+    ):
+        if not isinstance(target_storage, UCStorage):
+            raise ValueError(
+                "StagingExecutor requires target_storage to be a UCStorage instance "
+                "(staging only makes sense when the target is UC-governed)."
+            )
+        if not isinstance(source_storage, AWSStorage):
+            raise NotImplementedError(
+                "Cross-cloud staging is not supported in v1. "
+                f"Got source_storage={type(source_storage).__name__}; expected AWSStorage."
+            )
+        if not target_table_root or not source_table_root:
+            raise ValueError("target_table_root and source_table_root must be non-empty.")
+
+        self.source = source_storage
+        self.target = target_storage
+        # Normalize: bucket-relative, no leading/trailing slash.
+        self._target_root = self._strip_scheme(target_table_root).rstrip("/")
+        self._source_root = self._strip_scheme(source_table_root).rstrip("/")
+        self._chunk_size = chunk_size
+
+    def stage_file(self, source_path: str, expected_size: int) -> str:
+        """Copy one source file to the corresponding target location.
+
+        Args:
+            source_path: Bucket-relative source path as returned by PyArrow's
+                S3 filesystem (e.g.
+                ``"guidewire-bucket/cc_claim/abc123/20260101T000000Z/part-0.parquet"``).
+            expected_size: Source file size in bytes. Used for the
+                idempotency check on the target side.
+
+        Returns:
+            The bucket-relative target path the file was staged to (e.g.
+            ``"customer-bucket/staged/cc_claim/abc123/20260101T000000Z/part-0.parquet"``).
+
+        Raises:
+            ValueError: If ``source_path`` is not enclosed by the configured
+                ``source_table_root`` -- this would mean the manifest is
+                inconsistent with the staging configuration.
+        """
+        target_path = self._map_path(source_path)
+        if self._already_staged(target_path, expected_size):
+            L.debug(f"Skip already-staged: {target_path}")
+            return target_path
+
+        L.debug(f"Staging {source_path} -> {target_path}")
+        with self.source.filesystem.open_input_stream(source_path) as src:
+            with self.target.filesystem.open_output_stream(target_path) as dst:
+                while True:
+                    chunk = src.read(self._chunk_size)
+                    if not chunk:
+                        break
+                    dst.write(chunk)
+        return target_path
+
+    def _map_path(self, source_path: str) -> str:
+        """Translate a source bucket-relative path to its target location.
+
+        The source root is stripped and the result is appended to the target
+        root, preserving the per-table CDA layout
+        (``<schema_hash>/<timestamp>/*.parquet``).
+        """
+        normalized = self._strip_scheme(source_path)
+        if not normalized.startswith(self._source_root):
+            raise ValueError(
+                f"Source file {source_path!r} is not enclosed by source_table_root "
+                f"{self._source_root!r}; cannot map to a target location."
+            )
+        suffix = normalized[len(self._source_root):].lstrip("/")
+        return f"{self._target_root}/{suffix}"
+
+    def _already_staged(self, target_path: str, expected_size: int) -> bool:
+        """Return True if the target already has a file of the expected size."""
+        try:
+            info = self.target.filesystem.get_file_info(target_path)
+        except Exception:
+            return False
+        return info.type == FileType.File and info.size == expected_size
+
+    @staticmethod
+    def _strip_scheme(uri: str) -> str:
+        """Strip ``s3://``, ``s3a://``, or ``abfss://`` from the start of a URI."""
+        for scheme in ("s3://", "s3a://", "abfss://"):
+            if uri.startswith(scheme):
+                return uri[len(scheme):]
+        return uri

--- a/guidewire/storage.py
+++ b/guidewire/storage.py
@@ -1,8 +1,12 @@
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from threading import Lock
 import pyarrow as pa
 import pyarrow.fs as pa_fs
 import pyarrow.parquet as pq
 import pyarrow.json as pj
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.catalog import TableOperation
 from guidewire.logging import logger as L
 import os
 from typing import Literal, List, Dict, Any, Optional
@@ -141,13 +145,13 @@ class BaseStorage(ABC):
     
     def get_file_info(self, path: str) -> List[pa_fs.FileInfo]:
         """Get information about files in a directory.
-        
+
         Args:
             path: Directory path to get info for
-            
+
         Returns:
             List of FileInfo objects
-            
+
         Raises:
             FileNotFoundError: If the directory doesn't exist
         """
@@ -157,6 +161,24 @@ class BaseStorage(ABC):
         except Exception as e:
             L.error(f"Failed to get file info for {path}: {str(e)}")
             raise
+
+    def log_action_path(self, file_path: str, table_root: str) -> str:
+        """Format a file path for inclusion in a Delta AddAction.
+
+        Default behavior preserves the legacy upstream output: an absolute
+        ``s3a://`` path. Subclasses (notably ``UCStorage``) may override this
+        to emit paths relative to the table root, which is required for the
+        AddAction to stay within a Unity Catalog external location.
+
+        Args:
+            file_path: Source parquet path as returned by the manifest filesystem
+                (e.g. ``"bucket/schema_hash/timestamp/file.parquet"``).
+            table_root: Target Delta table URI (e.g. ``"s3://bucket/table/"``).
+
+        Returns:
+            Path string to record in the AddAction.
+        """
+        return f"s3a://{file_path}"
 
 
 class AzureStorage(BaseStorage):
@@ -344,10 +366,132 @@ class AWSStorage(BaseStorage):
                 access_key=access_key,
                 secret_key=secret_key,
             )
-    
+
     @property
     def storage_options(self) -> Dict[str, str]:
         """Get storage options dictionary for delta-rs integration."""
         return self._storage_options
 
+
+class UCStorage(BaseStorage):
+    """Unity Catalog credential-vending storage for AWS S3.
+
+    Vends short-lived AWS credentials via the Databricks SDK's
+    ``temporary_table_credentials`` API and refreshes them proactively before
+    expiry. Unlike :class:`AWSStorage` (which reads static keys from the
+    environment), this class produces vended credentials whose use is recorded
+    in ``system.access.audit`` and attributed to the UC principal.
+
+    Two behaviors distinguish this class:
+
+    1. ``storage_options`` includes ``session_token`` -- required for delta-rs
+       to authenticate temporary credentials against S3.
+    2. ``log_action_path`` returns a path *relative to the table root*. UC
+       governance can only enforce policy on AddActions whose paths resolve
+       inside a UC external location; an absolute ``s3a://other-bucket/...``
+       AddAction would be resolved by the engine using whatever IAM identity
+       is present, bypassing UC entirely.
+
+    Args:
+        uc_table_id: Unity Catalog table ID for which to vend credentials.
+            Use the table's UC metastore-scoped UUID.
+        operation: ``"READ"`` or ``"READ_WRITE"``. Use ``"READ_WRITE"`` for
+            the target Delta log writer.
+        region: AWS region to bind the PyArrow ``S3FileSystem`` to. Falls back
+            to the ``AWS_REGION`` environment variable if not provided.
+    """
+
+    REFRESH_BUFFER_SECONDS = 300  # refresh 5 min before expiry
+
+    def __init__(
+        self,
+        uc_table_id: str,
+        operation: Literal["READ", "READ_WRITE"] = "READ_WRITE",
+        region: Optional[str] = None,
+    ):
+        super().__init__()
+        if not uc_table_id:
+            raise KeyError("uc_table_id must be a non-empty string")
+
+        self._wc = WorkspaceClient()
+        self._uc_table_id = uc_table_id
+        self._operation = TableOperation[operation]
+        self._region = region or os.environ.get("AWS_REGION", "")
+        self._lock = Lock()
+        self._expires_at = None
+        self._refresh_credentials()
+
+    def _refresh_credentials(self) -> None:
+        with self._lock:
+            resp = self._wc.temporary_table_credentials.generate_temporary_table_credentials(
+                table_id=self._uc_table_id,
+                operation=self._operation,
+            )
+            aws = resp.aws_temp_credentials
+            if aws is None:
+                raise RuntimeError(
+                    f"UC did not return AWS credentials for table_id={self._uc_table_id}; "
+                    f"the credential may be Azure or GCP-backed."
+                )
+            self._storage_options = {
+                "region": self._region,
+                "access_key_id": aws.access_key_id,
+                "secret_access_key": aws.secret_access_key,
+                "session_token": aws.session_token,
+            }
+            self.filesystem = pa_fs.S3FileSystem(
+                region=self._region or None,
+                access_key=aws.access_key_id,
+                secret_key=aws.secret_access_key,
+                session_token=aws.session_token,
+            )
+            # expiration_time is epoch milliseconds per the SDK contract.
+            self._expires_at = resp.expiration_time
+
+    def _ensure_fresh(self) -> None:
+        if self._expires_at is None:
+            return
+        now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+        if (self._expires_at - now_ms) / 1000 < self.REFRESH_BUFFER_SECONDS:
+            self._refresh_credentials()
+
+    @property
+    def storage_options(self) -> Dict[str, str]:
+        """Get storage options dictionary for delta-rs integration.
+
+        Refreshes credentials proactively if they're within
+        :attr:`REFRESH_BUFFER_SECONDS` of expiry.
+        """
+        self._ensure_fresh()
+        return self._storage_options
+
+    def log_action_path(self, file_path: str, table_root: str) -> str:
+        """Emit a path relative to the table root, or raise.
+
+        UC governance requires AddAction paths to resolve inside a UC external
+        location. The simplest and most robust enforcement is to require the
+        source files to be enclosed by the target table root.
+
+        Raises:
+            ValueError: If ``file_path`` is not enclosed by ``table_root``
+                (cross-bucket layout). Configure source and target prefixes
+                under the same UC external location to fix.
+        """
+        prefix = self._normalize_table_root(table_root)
+        if not file_path.startswith(prefix):
+            raise ValueError(
+                "UC governance requires source files to be enclosed by the target table root. "
+                f"file={file_path!r} table_root={table_root!r}. "
+                "Configure source and target prefixes under the same UC external location."
+            )
+        return file_path[len(prefix):].lstrip("/")
+
+    @staticmethod
+    def _normalize_table_root(table_root: str) -> str:
+        """Strip the URI scheme from ``table_root`` so it can be compared against
+        the bucket-relative paths emitted by PyArrow's S3 filesystem."""
+        for scheme in ("s3://", "s3a://", "abfss://"):
+            if table_root.startswith(scheme):
+                return table_root[len(scheme):]
+        return table_root
 

--- a/main.py
+++ b/main.py
@@ -12,11 +12,28 @@ TABLE_NAMES: Tuple[str, ...] = (
 def main() -> None:
     """Main entry point for the application."""
     import os
-    
+
     # Get target cloud from environment variable, default to "azure" for backward compatibility
     target_cloud = os.environ.get("DELTA_TARGET_CLOUD", "azure")
-    
-    processor = Processor(target_cloud=target_cloud, table_names=TABLE_NAMES, parallel=False)
+
+    # Optional staging mode for Unity Catalog governance. When enabled, source
+    # parquets are copied into the UC-governed target before AddActions are
+    # written, so all reads stay inside a UC external location the customer
+    # controls. Required for Guidewire CDA SaaS deployments.
+    staging_mode = os.environ.get("STAGING_MODE", "false").lower() == "true"
+    uc_catalog = os.environ.get("UC_CATALOG_NAME")
+    uc_schema = os.environ.get("UC_SCHEMA_NAME")
+    uc_region = os.environ.get("UC_REGION") or os.environ.get("AWS_REGION")
+
+    processor = Processor(
+        target_cloud=target_cloud,
+        table_names=TABLE_NAMES,
+        parallel=False,
+        staging_mode=staging_mode,
+        uc_catalog=uc_catalog,
+        uc_schema=uc_schema,
+        uc_region=uc_region,
+    )
     processor.run()
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "ray[default]==2.45.0",
     "deltalake==1.2.1",
     "rich==14.1.0",
+    "databricks-sdk>=0.20.0",
     'importlib-metadata; python_version>"3.10"',
 ]
 

--- a/testing/tests/test_staging_unit.py
+++ b/testing/tests/test_staging_unit.py
@@ -1,0 +1,577 @@
+"""Unit tests for guidewire.staging.StagingExecutor.
+
+These tests verify the staging copy logic in isolation: path mapping,
+idempotency, the cross-filesystem stream copy, and integration with the
+modified ``Batch._get_parquet_list``. Filesystem operations are mocked --
+no real S3 (or LocalStack) is required.
+"""
+
+import io
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pyarrow as pa
+import pytest
+from pyarrow.fs import FileType
+
+from guidewire.staging import StagingExecutor
+from guidewire.storage import AWSStorage, AzureStorage, UCStorage
+
+
+def _build_uc_response(
+    access_key_id="vended-ak",
+    secret_access_key="vended-sk",
+    session_token="vended-st",
+    expiration_time=None,
+):
+    """Construct a mock GenerateTemporaryTableCredentialResponse (epoch ms)."""
+    if expiration_time is None:
+        expiration_time = int(datetime.now(timezone.utc).timestamp() * 1000) + 3_600_000
+    resp = MagicMock()
+    resp.aws_temp_credentials.access_key_id = access_key_id
+    resp.aws_temp_credentials.secret_access_key = secret_access_key
+    resp.aws_temp_credentials.session_token = session_token
+    resp.expiration_time = expiration_time
+    return resp
+
+
+def _build_uc_storage(region="us-east-1"):
+    """Construct a fully mocked UCStorage. Returns the UCStorage and the
+    mocked WorkspaceClient class so tests can adjust call expectations."""
+    with patch("guidewire.storage.WorkspaceClient") as mock_wc_cls:
+        mock_wc_cls.return_value.temporary_table_credentials.generate_temporary_table_credentials.return_value = (
+            _build_uc_response()
+        )
+        storage = UCStorage(uc_table_id="t1", region=region)
+    # Replace the underlying pyarrow filesystem with a mock so tests don't
+    # actually hit S3.
+    storage.filesystem = MagicMock()
+    return storage
+
+
+def _build_aws_source_storage():
+    env = {
+        "AWS_SOURCE_REGION": "us-east-1",
+        "AWS_SOURCE_ACCESS_KEY_ID": "k",
+        "AWS_SOURCE_SECRET_ACCESS_KEY": "s",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        storage = AWSStorage(prefix="SOURCE")
+    storage.filesystem = MagicMock()
+    return storage
+
+
+@pytest.mark.unit
+class TestStagingExecutor:
+    """Unit tests for StagingExecutor."""
+
+    def _build_executor(self, source_root="guidewire-bucket/cc_claim",
+                        target_root="customer-bucket/staged/cc_claim"):
+        source = _build_aws_source_storage()
+        target = _build_uc_storage()
+        executor = StagingExecutor(
+            source_storage=source,
+            target_storage=target,
+            target_table_root=f"s3://{target_root}/",
+            source_table_root=f"s3://{source_root}/",
+        )
+        return executor, source, target
+
+    # ---------- construction guards ----------
+
+    def test_construction_rejects_non_uc_target(self):
+        """target_storage must be a UCStorage instance."""
+        source = _build_aws_source_storage()
+        env = {
+            "AWS_TARGET_REGION": "us-east-1",
+            "AWS_TARGET_ACCESS_KEY_ID": "k",
+            "AWS_TARGET_SECRET_ACCESS_KEY": "s",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            non_uc_target = AWSStorage(prefix="TARGET")
+        with pytest.raises(ValueError, match="target_storage to be a UCStorage"):
+            StagingExecutor(
+                source_storage=source,
+                target_storage=non_uc_target,
+                target_table_root="s3://bucket/t/",
+                source_table_root="s3://src/t/",
+            )
+
+    def test_construction_rejects_non_aws_source(self):
+        """Cross-cloud staging is rejected in v1."""
+        env = {"AZURE_STORAGE_ACCOUNT_NAME": "a", "AZURE_STORAGE_ACCOUNT_KEY": "k"}
+        with patch.dict(os.environ, env, clear=True):
+            azure_source = AzureStorage()
+        target = _build_uc_storage()
+        with pytest.raises(NotImplementedError, match="Cross-cloud staging"):
+            StagingExecutor(
+                source_storage=azure_source,
+                target_storage=target,
+                target_table_root="s3://bucket/t/",
+                source_table_root="abfss://c@a.dfs.core.windows.net/t/",
+            )
+
+    def test_construction_rejects_empty_roots(self):
+        source = _build_aws_source_storage()
+        target = _build_uc_storage()
+        with pytest.raises(ValueError, match="non-empty"):
+            StagingExecutor(
+                source_storage=source,
+                target_storage=target,
+                target_table_root="",
+                source_table_root="s3://src/t/",
+            )
+
+    # ---------- path mapping ----------
+
+    def test_map_path_strips_source_root_and_prepends_target(self):
+        """Source path under source root maps to target root + relative suffix."""
+        executor, _, _ = self._build_executor()
+        target = executor._map_path(
+            "guidewire-bucket/cc_claim/abc123/20260101T000000Z/part-0.parquet"
+        )
+        assert target == "customer-bucket/staged/cc_claim/abc123/20260101T000000Z/part-0.parquet"
+
+    def test_map_path_handles_scheme_in_input(self):
+        """Source paths with s3:// or s3a:// scheme prefixes are normalized."""
+        executor, _, _ = self._build_executor()
+        target = executor._map_path(
+            "s3a://guidewire-bucket/cc_claim/abc/20260101T000000Z/file.parquet"
+        )
+        assert target == "customer-bucket/staged/cc_claim/abc/20260101T000000Z/file.parquet"
+
+    def test_map_path_raises_on_path_outside_source_root(self):
+        """Source path not enclosed by source_table_root raises."""
+        executor, _, _ = self._build_executor()
+        with pytest.raises(ValueError, match="not enclosed by source_table_root"):
+            executor._map_path("other-bucket/some/file.parquet")
+
+    # ---------- idempotency ----------
+
+    def test_already_staged_skips_when_target_size_matches(self):
+        """head_object returning matching size means no copy."""
+        executor, source, target = self._build_executor()
+
+        target_info = MagicMock()
+        target_info.type = FileType.File
+        target_info.size = 12345
+        target.filesystem.get_file_info.return_value = target_info
+
+        result = executor.stage_file(
+            source_path="guidewire-bucket/cc_claim/abc/20260101T000000Z/part-0.parquet",
+            expected_size=12345,
+        )
+        assert result == "customer-bucket/staged/cc_claim/abc/20260101T000000Z/part-0.parquet"
+        # Streams must NOT have been opened.
+        source.filesystem.open_input_stream.assert_not_called()
+        target.filesystem.open_output_stream.assert_not_called()
+
+    def test_already_staged_returns_false_on_size_mismatch(self):
+        """If target exists but size differs, copy proceeds (overwrite)."""
+        executor, source, target = self._build_executor()
+
+        target_info = MagicMock()
+        target_info.type = FileType.File
+        target_info.size = 999  # different from expected
+        target.filesystem.get_file_info.return_value = target_info
+
+        # Streams will be opened; provide context-manager-compatible mocks.
+        src_stream = MagicMock()
+        src_stream.read.side_effect = [b"data", b""]
+        source.filesystem.open_input_stream.return_value.__enter__.return_value = src_stream
+        target.filesystem.open_output_stream.return_value.__enter__.return_value = MagicMock()
+
+        executor.stage_file(
+            source_path="guidewire-bucket/cc_claim/abc/20260101T000000Z/part-0.parquet",
+            expected_size=12345,
+        )
+        source.filesystem.open_input_stream.assert_called_once()
+        target.filesystem.open_output_stream.assert_called_once()
+
+    def test_already_staged_returns_false_on_missing_target(self):
+        """get_file_info raising means target doesn't exist; copy proceeds."""
+        executor, source, target = self._build_executor()
+        target.filesystem.get_file_info.side_effect = FileNotFoundError("missing")
+
+        src_stream = MagicMock()
+        src_stream.read.side_effect = [b"hello", b""]
+        source.filesystem.open_input_stream.return_value.__enter__.return_value = src_stream
+        target.filesystem.open_output_stream.return_value.__enter__.return_value = MagicMock()
+
+        executor.stage_file(
+            source_path="guidewire-bucket/cc_claim/abc/20260101T000000Z/part-0.parquet",
+            expected_size=12345,
+        )
+        source.filesystem.open_input_stream.assert_called_once()
+
+    # ---------- streaming copy ----------
+
+    def test_stream_copy_writes_all_chunks(self):
+        """Bytes from source.read() are forwarded to target.write() in order."""
+        executor, source, target = self._build_executor()
+        target.filesystem.get_file_info.side_effect = FileNotFoundError()
+
+        chunks = [b"chunk1", b"chunk2", b"chunk3", b""]
+        src_stream = MagicMock()
+        src_stream.read.side_effect = chunks
+        dst_stream = MagicMock()
+        source.filesystem.open_input_stream.return_value.__enter__.return_value = src_stream
+        target.filesystem.open_output_stream.return_value.__enter__.return_value = dst_stream
+
+        target_path = executor.stage_file(
+            source_path="guidewire-bucket/cc_claim/abc/20260101T000000Z/p.parquet",
+            expected_size=18,
+        )
+        # Three chunks written in order, terminator chunk not written.
+        assert dst_stream.write.call_count == 3
+        written = [call.args[0] for call in dst_stream.write.call_args_list]
+        assert written == [b"chunk1", b"chunk2", b"chunk3"]
+        assert target_path.endswith("/p.parquet")
+
+    def test_stage_file_returns_correct_target_path(self):
+        """stage_file returns the bucket-relative target path."""
+        executor, source, target = self._build_executor()
+        target.filesystem.get_file_info.side_effect = FileNotFoundError()
+        src_stream = MagicMock()
+        src_stream.read.side_effect = [b""]
+        source.filesystem.open_input_stream.return_value.__enter__.return_value = src_stream
+        target.filesystem.open_output_stream.return_value.__enter__.return_value = MagicMock()
+
+        target_path = executor.stage_file(
+            source_path="guidewire-bucket/cc_claim/abc/20260101T000000Z/file.parquet",
+            expected_size=0,
+        )
+        assert target_path == "customer-bucket/staged/cc_claim/abc/20260101T000000Z/file.parquet"
+
+    # ---------- normalization helpers ----------
+
+    def test_strip_scheme_handles_s3_s3a_abfss(self):
+        assert StagingExecutor._strip_scheme("s3://b/k") == "b/k"
+        assert StagingExecutor._strip_scheme("s3a://b/k") == "b/k"
+        assert StagingExecutor._strip_scheme("abfss://c@a.dfs.core.windows.net/k") == "c@a.dfs.core.windows.net/k"
+        assert StagingExecutor._strip_scheme("plain/path") == "plain/path"
+
+    def test_root_normalization_handles_trailing_slashes(self):
+        """Constructor strips trailing slashes from roots."""
+        source = _build_aws_source_storage()
+        target = _build_uc_storage()
+        executor = StagingExecutor(
+            source_storage=source,
+            target_storage=target,
+            target_table_root="s3://customer-bucket/staged/cc_claim///",
+            source_table_root="s3://guidewire-bucket/cc_claim///",
+        )
+        assert executor._target_root == "customer-bucket/staged/cc_claim"
+        assert executor._source_root == "guidewire-bucket/cc_claim"
+
+
+@pytest.mark.unit
+class TestBatchStagingIntegration:
+    """End-to-end tests showing Batch correctly routes through staging."""
+
+    def test_batch_staging_requires_uc_storage(self):
+        """Batch(staging=True) without UCStorage target raises."""
+        from guidewire.batch import Batch
+        # Mock heavy dependencies on Batch construction. We rely on early
+        # validation in Batch.__init__ to raise before reaching them.
+        env = {
+            "AWS_TARGET_REGION": "us-east-1",
+            "AWS_TARGET_ACCESS_KEY_ID": "k",
+            "AWS_TARGET_SECRET_ACCESS_KEY": "s",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            non_uc = AWSStorage(prefix="TARGET")
+
+        manifest_mock = MagicMock()
+        manifest_mock.read.return_value = {
+            "dataFilesPath": "s3://guidewire-bucket/cc_claim/",
+            "schemaHistory": {},
+            "lastSuccessfulWriteTimestamp": "0",
+            "totalProcessedRecordsCount": 0,
+        }
+
+        with patch("guidewire.delta_log.AWSDeltaLog._log_exists"):
+            with patch.object(
+                __import__("guidewire.delta_log", fromlist=["AWSDeltaLog"]).AWSDeltaLog,
+                "_get_watermark_from_log",
+                return_value={"watermark": 0, "schema_timestamp": 0},
+            ):
+                with pytest.raises(ValueError, match="staging_mode=True requires"):
+                    Batch(
+                        table_name="cc_claim",
+                        manifest=manifest_mock,
+                        target_cloud="aws",
+                        storage_or_s3_name="customer-bucket",
+                        storage_container=None,
+                        target_storage=non_uc,
+                        staging_mode=True,
+                    )
+
+    def test_batch_staging_rejects_azure_target(self):
+        """Batch(staging=True, target_cloud='azure') raises NotImplementedError."""
+        from guidewire.batch import Batch
+        target = _build_uc_storage()
+
+        manifest_mock = MagicMock()
+        manifest_mock.read.return_value = {
+            "dataFilesPath": "s3://guidewire-bucket/cc_claim/",
+            "schemaHistory": {},
+            "lastSuccessfulWriteTimestamp": "0",
+            "totalProcessedRecordsCount": 0,
+        }
+
+        env = {"AZURE_STORAGE_ACCOUNT_NAME": "a", "AZURE_STORAGE_ACCOUNT_KEY": "k"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch("guidewire.delta_log.AzureDeltaLog._log_exists"):
+                with patch.object(
+                    __import__("guidewire.delta_log", fromlist=["AzureDeltaLog"]).AzureDeltaLog,
+                    "_get_watermark_from_log",
+                    return_value={"watermark": 0, "schema_timestamp": 0},
+                ):
+                    with pytest.raises(NotImplementedError, match="staging_mode=True is supported only"):
+                        Batch(
+                            table_name="cc_claim",
+                            manifest=manifest_mock,
+                            target_cloud="azure",
+                            storage_or_s3_name="acct",
+                            storage_container="container",
+                            target_storage=target,
+                            staging_mode=True,
+                        )
+
+    def test_processor_staging_rejects_azure_target_cloud(self):
+        """Processor(staging_mode=True, target_cloud='azure') raises NotImplementedError."""
+        from guidewire.processor import Processor
+        env = {
+            "AWS_MANIFEST_LOCATION": "s3://test-bucket/manifest.json",
+            "AZURE_STORAGE_ACCOUNT_NAME": "a",
+            "AZURE_STORAGE_ACCOUNT_CONTAINER": "c",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch("guidewire.processor.Manifest"):
+                with pytest.raises(NotImplementedError, match="staging_mode is supported only"):
+                    Processor(
+                        target_cloud="azure",
+                        table_names=("t1",),
+                        parallel=False,
+                        staging_mode=True,
+                        uc_catalog="cat",
+                        uc_schema="sch",
+                    )
+
+    def test_processor_staging_requires_uc_catalog_and_schema(self):
+        """Processor(staging_mode=True) without uc_catalog/uc_schema raises ValueError."""
+        from guidewire.processor import Processor
+        env = {
+            "AWS_MANIFEST_LOCATION": "s3://test-bucket/manifest.json",
+            "AWS_S3_BUCKET": "target-bucket",
+            "AWS_REGION": "us-east-1",
+            "AWS_ACCESS_KEY_ID": "k",
+            "AWS_SECRET_ACCESS_KEY": "s",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch("guidewire.processor.Manifest"):
+                with pytest.raises(ValueError, match="staging_mode=True requires uc_catalog"):
+                    Processor(
+                        target_cloud="aws",
+                        table_names=("t1",),
+                        parallel=False,
+                        staging_mode=True,
+                        uc_catalog=None,
+                        uc_schema=None,
+                    )
+
+    def test_processor_staging_resolves_uc_table_ids(self):
+        """Processor(staging_mode=True) calls WorkspaceClient.tables.get per table."""
+        from guidewire.processor import Processor
+        env = {
+            "AWS_MANIFEST_LOCATION": "s3://test-bucket/manifest.json",
+            "AWS_S3_BUCKET": "target-bucket",
+            "AWS_REGION": "us-east-1",
+            "AWS_ACCESS_KEY_ID": "k",
+            "AWS_SECRET_ACCESS_KEY": "s",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch("guidewire.processor.Manifest") as mock_manifest:
+                mock_manifest.return_value.get_table_names.return_value = ["t1", "t2"]
+                with patch("guidewire.processor.WorkspaceClient") as mock_wc_cls:
+                    # Each tables.get returns an object with table_id=resolved-<full-name>
+                    def fake_get(full_name):
+                        m = MagicMock()
+                        m.table_id = f"id-for-{full_name}"
+                        return m
+                    mock_wc_cls.return_value.tables.get.side_effect = fake_get
+
+                    processor = Processor(
+                        target_cloud="aws",
+                        table_names=("t1", "t2"),
+                        parallel=False,
+                        staging_mode=True,
+                        uc_catalog="my_cat",
+                        uc_schema="my_sch",
+                    )
+
+                    assert processor._uc_table_ids == {
+                        "t1": "id-for-my_cat.my_sch.t1",
+                        "t2": "id-for-my_cat.my_sch.t2",
+                    }
+                    assert mock_wc_cls.return_value.tables.get.call_count == 2
+
+    def test_batch_no_staging_keeps_legacy_path_format(self):
+        """Without staging=True, _get_parquet_list emits absolute s3a:// paths."""
+        from guidewire.batch import Batch
+        env = {
+            "AWS_TARGET_REGION": "us-east-1",
+            "AWS_TARGET_ACCESS_KEY_ID": "k",
+            "AWS_TARGET_SECRET_ACCESS_KEY": "s",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch("guidewire.delta_log.AWSDeltaLog._log_exists"):
+                with patch.object(
+                    __import__("guidewire.delta_log", fromlist=["AWSDeltaLog"]).AWSDeltaLog,
+                    "_get_watermark_from_log",
+                    return_value={"watermark": 0, "schema_timestamp": 0},
+                ):
+                    manifest_mock = MagicMock()
+                    manifest_mock.read.return_value = {
+                        "dataFilesPath": "s3://guidewire-bucket/cc_claim/",
+                        "schemaHistory": {},
+                        "lastSuccessfulWriteTimestamp": "0",
+                        "totalProcessedRecordsCount": 0,
+                    }
+
+                    # Mock manifest.fs.get_file_info to return a single parquet file.
+                    file_info = MagicMock()
+                    file_info.path = "guidewire-bucket/cc_claim/abc/ts/file.parquet"
+                    file_info.size = 100
+                    file_info.mtime_ns = 1_700_000_000_000_000_000
+                    file_info.type = FileType.File
+                    manifest_mock.fs.get_file_info.return_value = [file_info]
+
+                    batch = Batch(
+                        table_name="cc_claim",
+                        manifest=manifest_mock,
+                        target_cloud="aws",
+                        storage_or_s3_name="customer-bucket",
+                        storage_container=None,
+                    )
+                    assert batch.staging_executor is None
+                    files = batch._get_parquet_list("guidewire-bucket/cc_claim/abc/ts/")
+                    assert len(files) == 1
+                    assert files[0]["path"] == "s3a://guidewire-bucket/cc_claim/abc/ts/file.parquet"
+
+    def test_batch_staging_calls_stage_file_and_emits_relative_path(self):
+        """End-to-end: Batch(staging_mode=True) routes _get_parquet_list through
+        StagingExecutor.stage_file and emits paths relative to the target root.
+
+        This is the integration test that proves the polymorphic dispatch in
+        Batch._get_parquet_list works with staging enabled. It exercises:
+          1. Batch constructs StagingExecutor automatically when staging_mode=True
+          2. _get_parquet_list calls staging_executor.stage_file per parquet
+          3. The returned path is the staged target path passed through
+             UCStorage.log_action_path -- i.e. relative to the target table root
+        """
+        from guidewire.batch import Batch
+        target = _build_uc_storage()
+
+        manifest_mock = MagicMock()
+        manifest_mock.read.return_value = {
+            "dataFilesPath": "s3://guidewire-bucket/cc_claim/",
+            "schemaHistory": {},
+            "lastSuccessfulWriteTimestamp": "0",
+            "totalProcessedRecordsCount": 0,
+        }
+
+        # Two synthetic parquet files in the source listing.
+        files_meta = [
+            ("guidewire-bucket/cc_claim/abc/20260101T000000Z/part-0.parquet", 100),
+            ("guidewire-bucket/cc_claim/abc/20260101T000000Z/part-1.parquet", 200),
+        ]
+        file_infos = []
+        for path, size in files_meta:
+            f = MagicMock()
+            f.path = path
+            f.size = size
+            f.mtime_ns = 1_700_000_000_000_000_000
+            f.type = FileType.File
+            file_infos.append(f)
+        manifest_mock.fs = MagicMock()
+        manifest_mock.fs.get_file_info.return_value = file_infos
+        # Important: AWSStorage(prefix="SOURCE") instance check inside StagingExecutor
+        # must succeed, so wrap with a real AWSStorage.
+        env = {
+            "AWS_SOURCE_REGION": "us-east-1",
+            "AWS_SOURCE_ACCESS_KEY_ID": "k",
+            "AWS_SOURCE_SECRET_ACCESS_KEY": "s",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            real_source = AWSStorage(prefix="SOURCE")
+        real_source.filesystem = MagicMock()
+        manifest_mock.fs = real_source
+
+        # Re-set get_file_info on the real source's underlying mock filesystem,
+        # since manifest_mock.fs is now real_source (an AWSStorage).
+        real_source.filesystem.get_file_info = MagicMock(return_value=file_infos)
+        # Pre-populate the target so _already_staged returns False (source not
+        # in target) and the stream copy proceeds.
+        target.filesystem.get_file_info.side_effect = FileNotFoundError()
+        # Stub out streams for the copy. Each open() returns a fresh stream
+        # whose read() yields one chunk then EOF -- otherwise the side_effect
+        # list runs out across multiple files.
+        def fresh_input_stream():
+            stream = MagicMock()
+            stream.read.side_effect = [b"x", b""]
+            ctx = MagicMock()
+            ctx.__enter__.return_value = stream
+            ctx.__exit__.return_value = False
+            return ctx
+
+        def fresh_output_stream():
+            ctx = MagicMock()
+            ctx.__enter__.return_value = MagicMock()
+            ctx.__exit__.return_value = False
+            return ctx
+
+        real_source.filesystem.open_input_stream.side_effect = lambda *args, **kwargs: fresh_input_stream()
+        target.filesystem.open_output_stream.side_effect = lambda *args, **kwargs: fresh_output_stream()
+
+        with patch("guidewire.delta_log.AWSDeltaLog._log_exists"):
+            with patch.object(
+                __import__("guidewire.delta_log", fromlist=["AWSDeltaLog"]).AWSDeltaLog,
+                "_get_watermark_from_log",
+                return_value={"watermark": 0, "schema_timestamp": 0},
+            ):
+                batch = Batch(
+                    table_name="cc_claim",
+                    manifest=manifest_mock,
+                    target_cloud="aws",
+                    # storage_or_s3_name maps to the AWSDeltaLog bucket. Choose
+                    # a value that produces a known log_uri so we can assert on
+                    # the relative path output below.
+                    storage_or_s3_name="guidewire-bucket",
+                    storage_container=None,
+                    target_storage=target,
+                    staging_mode=True,
+                )
+
+                # Sanity: staging executor was constructed, target/source roots populated.
+                assert batch.staging_executor is not None
+                assert batch.staging_executor._source_root == "guidewire-bucket/cc_claim"
+                # log_uri is "s3://guidewire-bucket/cc_claim/" since
+                # AWSDeltaLog.construct_log_uri = f"s3://{bucket}/{table}/"
+                assert batch.staging_executor._target_root == "guidewire-bucket/cc_claim"
+
+                files = batch._get_parquet_list("guidewire-bucket/cc_claim/abc/20260101T000000Z/")
+                assert len(files) == 2
+                # Path 1 (post-stage): relative to target root, with
+                # source_root == target_root in this test the staged path is
+                # identical to the source layout under the target.
+                assert files[0]["path"] == "abc/20260101T000000Z/part-0.parquet"
+                assert files[1]["path"] == "abc/20260101T000000Z/part-1.parquet"
+                # Sizes preserved
+                assert files[0]["size"] == 100
+                assert files[1]["size"] == 200
+                # Streams opened twice (one per file).
+                assert real_source.filesystem.open_input_stream.call_count == 2
+                assert target.filesystem.open_output_stream.call_count == 2

--- a/testing/tests/test_target_cloud_config.py
+++ b/testing/tests/test_target_cloud_config.py
@@ -7,11 +7,12 @@ without requiring external cloud services.
 
 import pytest
 import os
+from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 
 from guidewire.processor import Processor
 from guidewire.delta_log import AzureDeltaLog, AWSDeltaLog, DeltaValidationError
-from guidewire.storage import AWSStorage
+from guidewire.storage import AWSStorage, AzureStorage, UCStorage
 
 
 @pytest.mark.unit
@@ -387,8 +388,163 @@ class TestTargetCloudConfiguration:
         
         with patch.dict(os.environ, env_vars, clear=True):
             storage = AWSStorage(prefix="TARGET")
-            
+
             assert storage._storage_options["region"] == "us-west-2"
             assert storage._storage_options["access_key_id"] == "target-key"
-            assert storage._storage_options["secret_access_key"] == "target-secret"  
+            assert storage._storage_options["secret_access_key"] == "target-secret"
             assert storage._storage_options["endpoint"] == "https://s3.us-west-2.amazonaws.com"
+
+    # -----------------------------------------------------------------
+    # Tests for log_action_path polymorphism and the optional
+    # ``storage`` parameter on AWSDeltaLog. Together these confirm that
+    # opting in to UCStorage produces relative-path AddActions while every
+    # existing call site keeps emitting absolute s3a:// paths.
+    # -----------------------------------------------------------------
+
+    def test_storage_aws_log_action_path_legacy(self):
+        """AWSStorage.log_action_path returns the legacy absolute s3a:// path.
+
+        Backward-compatibility regression guard: any existing caller that
+        does not opt into UCStorage must see an unchanged AddAction path
+        format.
+        """
+        env_vars = {
+            "AWS_REGION": "us-east-1",
+            "AWS_ACCESS_KEY_ID": "k",
+            "AWS_SECRET_ACCESS_KEY": "s",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            storage = AWSStorage()
+            assert storage.log_action_path(
+                file_path="my-bucket/schema_hash/20260101T000000Z/part-0.parquet",
+                table_root="s3://my-bucket/cc_claim/",
+            ) == "s3a://my-bucket/schema_hash/20260101T000000Z/part-0.parquet"
+
+    def test_storage_azure_log_action_path_legacy(self):
+        """AzureStorage inherits the BaseStorage default log_action_path."""
+        env_vars = {
+            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
+            "AZURE_STORAGE_ACCOUNT_KEY": "k",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            storage = AzureStorage()
+            assert storage.log_action_path(
+                file_path="container/path/file.parquet",
+                table_root="abfss://c@a.dfs.core.windows.net/t/",
+            ) == "s3a://container/path/file.parquet"
+
+    def test_delta_log_aws_default_storage_unchanged(self):
+        """AWSDeltaLog without `storage=` still constructs AWSStorage(prefix='TARGET').
+
+        Backward-compatibility regression guard: the no-arg call shape used
+        throughout the existing codebase keeps its meaning.
+        """
+        env_vars = {
+            "AWS_TARGET_REGION": "us-east-1",
+            "AWS_TARGET_ACCESS_KEY_ID": "tk",
+            "AWS_TARGET_SECRET_ACCESS_KEY": "ts",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            with patch.object(AWSDeltaLog, '_log_exists'):
+                delta_log = AWSDeltaLog(bucket_name="b", table_name="t")
+                assert isinstance(delta_log.fs, AWSStorage)
+                assert delta_log.fs._storage_options["access_key_id"] == "tk"
+
+    @staticmethod
+    def _build_uc_response(
+        access_key_id="vended-ak",
+        secret_access_key="vended-sk",
+        session_token="vended-st",
+        expiration_time=None,
+    ):
+        """Construct a mock GenerateTemporaryTableCredentialResponse."""
+        if expiration_time is None:
+            # Default: 1 hour in the future, in epoch ms (per SDK contract).
+            expiration_time = int(datetime.now(timezone.utc).timestamp() * 1000) + 3_600_000
+        resp = MagicMock()
+        resp.aws_temp_credentials.access_key_id = access_key_id
+        resp.aws_temp_credentials.secret_access_key = secret_access_key
+        resp.aws_temp_credentials.session_token = session_token
+        resp.expiration_time = expiration_time
+        return resp
+
+    def test_storage_uc_init(self):
+        """UCStorage init populates storage_options with vended credentials."""
+        with patch('guidewire.storage.WorkspaceClient') as mock_wc_cls:
+            mock_wc_cls.return_value.temporary_table_credentials.generate_temporary_table_credentials.return_value = (
+                self._build_uc_response()
+            )
+
+            storage = UCStorage(uc_table_id="abc-123", region="us-east-1")
+
+            opts = storage.storage_options
+            assert opts["region"] == "us-east-1"
+            assert opts["access_key_id"] == "vended-ak"
+            assert opts["secret_access_key"] == "vended-sk"
+            assert opts["session_token"] == "vended-st"
+            # Confirm the SDK was called with the right operation enum.
+            call_kwargs = mock_wc_cls.return_value.temporary_table_credentials.generate_temporary_table_credentials.call_args.kwargs
+            assert call_kwargs["table_id"] == "abc-123"
+
+    def test_storage_uc_log_action_path_relative(self):
+        """UCStorage.log_action_path emits a path relative to the table root."""
+        with patch('guidewire.storage.WorkspaceClient') as mock_wc_cls:
+            mock_wc_cls.return_value.temporary_table_credentials.generate_temporary_table_credentials.return_value = (
+                self._build_uc_response()
+            )
+            storage = UCStorage(uc_table_id="t1")
+
+            relative = storage.log_action_path(
+                file_path="my-bucket/cc_claim/schema_hash/20260101T000000Z/part-0.parquet",
+                table_root="s3://my-bucket/cc_claim/",
+            )
+            assert relative == "schema_hash/20260101T000000Z/part-0.parquet"
+
+    def test_storage_uc_log_action_path_cross_bucket_raises(self):
+        """UCStorage rejects source files outside the target table root."""
+        with patch('guidewire.storage.WorkspaceClient') as mock_wc_cls:
+            mock_wc_cls.return_value.temporary_table_credentials.generate_temporary_table_credentials.return_value = (
+                self._build_uc_response()
+            )
+            storage = UCStorage(uc_table_id="t1")
+
+            with pytest.raises(ValueError, match="UC governance requires"):
+                storage.log_action_path(
+                    file_path="other-bucket/some/path/file.parquet",
+                    table_root="s3://my-bucket/cc_claim/",
+                )
+
+    def test_storage_uc_credentials_refresh_before_expiry(self):
+        """Accessing storage_options near expiry triggers a re-vend."""
+        with patch('guidewire.storage.WorkspaceClient') as mock_wc_cls:
+            gen = mock_wc_cls.return_value.temporary_table_credentials.generate_temporary_table_credentials
+            # First call (in __init__): credentials expire in 60s — well within the 300s buffer.
+            now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+            gen.return_value = self._build_uc_response(expiration_time=now_ms + 60_000)
+
+            storage = UCStorage(uc_table_id="t1")
+            assert gen.call_count == 1
+
+            # Second call (during storage_options access): plenty of headroom.
+            gen.return_value = self._build_uc_response(expiration_time=now_ms + 3_600_000)
+
+            _ = storage.storage_options  # property access should trigger refresh
+            assert gen.call_count == 2
+
+    def test_delta_log_aws_with_uc_storage_param(self):
+        """AWSDeltaLog uses caller-supplied storage instead of constructing AWSStorage."""
+        with patch('guidewire.storage.WorkspaceClient') as mock_wc_cls:
+            mock_wc_cls.return_value.temporary_table_credentials.generate_temporary_table_credentials.return_value = (
+                self._build_uc_response()
+            )
+            uc = UCStorage(uc_table_id="t1", region="us-east-1")
+
+            with patch.object(AWSDeltaLog, '_log_exists'):
+                delta_log = AWSDeltaLog(
+                    bucket_name="b",
+                    table_name="t",
+                    storage=uc,
+                )
+
+                assert delta_log.fs is uc
+                assert "session_token" in delta_log.storage_options


### PR DESCRIPTION
## Summary

The accelerator's `_delta_log` records AddActions with absolute `s3a://...` paths. When the resulting Delta table is queried, the engine resolves those paths using whatever IAM identity it has -- bypassing Unity Catalog governance entirely. On classic compute with a broad cluster IAM, this is a silent governance bypass; on serverless, it is a fail-closed read.

This PR adds Unity Catalog support as a non-breaking, opt-in feature. Two commits, layered:

1. **`UCStorage` + relative-path AddActions** (protocol fix) -- works for self-hosted CDA where the customer owns the source bucket.
2. **Staging mode** -- copies source parquets into a UC-governed bucket before recording AddActions. Required for the typical Guidewire CDA SaaS deployment, where the source bucket is owned by Guidewire and not registerable as a UC external location.

Both commits preserve bit-identical legacy behavior when the new options are not used. See `STAGING_MODE.md` (added by commit 2) for setup, configuration, and limitations.

## Backward compatibility

Every change is opt-in:
- Without `target_storage`, `AWSStorage(prefix="TARGET")` is constructed exactly as before.
- Without `staging_mode`, no staging executor is created and `_get_parquet_list` emits `f"s3a://{file.path}"` -- bit-identical AddAction paths.
- `Processor` only calls the Databricks SDK when `staging_mode=True` is requested.

Four explicit regression-guard tests lock this in:
- `test_storage_aws_log_action_path_legacy`
- `test_storage_azure_log_action_path_legacy`
- `test_delta_log_aws_default_storage_unchanged`
- `test_batch_no_staging_keeps_legacy_path_format`

## v1 limitations (documented in STAGING_MODE.md)

- AWS source -> AWS UC target only. Cross-cloud staging raises `NotImplementedError`.
- Sequential within-table copy (cross-table parallelism via Ray preserved).
- Idempotency uses S3 `head_object` size match. A partial-file failure with byte-count collision is a known small window.

## Test plan

- [x] `pytest testing/tests -v -m unit` passes locally: `84 passed, 60 deselected, 0 failed` (was 56 baseline -- net +28 tests, 0 regressions)
- [x] Backward compatibility regression guards pass
- [x] Pre-commit and pre-push hooks pass (Databricks secret scanner)
- [ ] Integration tests against LocalStack (`make test`) -- not run on this branch; deferred to reviewer or follow-up
- [ ] Manual smoke against a real Databricks workspace with UC + S3 external location -- recommended before merge

This pull request and its description were written by Isaac.